### PR TITLE
Use released upstream packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         ros_repo: [ main, testing ]
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
-      UPSTREAM_WORKSPACE: .rosinstall
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         CLANG_FORMAT_VERSION: "10"
   industrial_ci:
     strategy:
+      fail-fast: false
       matrix:
         ros_distro: [ melodic, noetic ]
         ros_repo: [ main, testing ]

--- a/.rosinstall
+++ b/.rosinstall
@@ -1,8 +1,0 @@
-- git:
-    uri: https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers
-    local-name: scaled_controllers
-    version: main
-- git:
-    uri: https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs
-    local-name: cartesian_control_msgs
-    version: main


### PR DESCRIPTION
The upstream packages have been released, so we should use them for the CI

For now, only the TESTING builds are expected to succeed until the next syncs are done.