### PR TITLE
Make control update open-loop without active action

### DIFF
--- a/cartesian_trajectory_controller/include/cartesian_trajectory_controller/cartesian_trajectory_controller.hpp
+++ b/cartesian_trajectory_controller/include/cartesian_trajectory_controller/cartesian_trajectory_controller.hpp
@@ -125,10 +125,6 @@ void CartesianTrajectoryController<HWInterface>::update(const ros::Time& time, c
       timesUp();
     }
   }
-  else  // Stay where we are
-  {
-    ControlPolicy::updateCommand(ControlPolicy::getState());
-  }
 }
 
 template <class HWInterface>


### PR DESCRIPTION
This shall fix controller drifts when the controller's action server is
in idle state. These drifts seem to appear when continuously
mirroring the robot's current state as fresh target state in the
controller's update().

Note that the RobotHW still sends commands from the
command buffer in each cycle.
The difference is that the Cartesian trajectory controller now updates
this buffer only when its action sever processes a request, making the
idle state open loop.

Thanks to @A13x15 and @urmahp for finding and reproducing this bug.

---

Edit: Issue came up [here](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/390).