### PR TITLE
Rename twist controller's library target

### DIFF
--- a/twist_controller/CMakeLists.txt
+++ b/twist_controller/CMakeLists.txt
@@ -130,7 +130,8 @@ include_directories(
 )
 
 ## Declare a C++ library
-add_library(${PROJECT_NAME}
+set(LIBRARY_NAME cartesian_${PROJECT_NAME}) # Avoid clashes with IPA's cob_twist_controller
+add_library(${LIBRARY_NAME}
   src/twist_controller.cpp
 )
 
@@ -139,7 +140,7 @@ add_library(${PROJECT_NAME}
 ## Add cmake target dependencies of the library
 ## as an example, code may need to be generated before libraries
 ## either from message generation or dynamic reconfigure
-add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${LIBRARY_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Declare a C++ executable
 ## With catkin_make all packages are built within a single CMake context
@@ -157,7 +158,7 @@ add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EX
 # add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${LIBRARY_NAME}
   ${catkin_LIBRARIES}
 )
 
@@ -183,7 +184,7 @@ target_link_libraries(${PROJECT_NAME}
 
 ## Mark libraries for installation
 ## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${LIBRARY_NAME}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}

--- a/twist_controller/twist_controller_plugin.xml
+++ b/twist_controller/twist_controller_plugin.xml
@@ -1,4 +1,4 @@
-<library path="lib/libtwist_controller">
+<library path="lib/libcartesian_twist_controller">
   <class name="ros_controllers_cartesian/TwistController"
          type="ros_controllers_cartesian::TwistController"
          base_class_type="controller_interface::ControllerBase">


### PR DESCRIPTION
## Goal
Avoid library clashes with IPA's [cob_twist_controller](https://github.com/ipa320/cob_control/tree/melodic_dev/cob_twist_controller).

Fixes #9 

## Approach
- Only rename the respective library target.
- This makes it simple for people already using our `twist_controller`.

## Steps
- [x] Rename library target
- [ ] Make a new release