### PR TITLE
Added a check to ensure that the shortest path is followed when inter…

### DIFF
--- a/cartesian_trajectory_interpolation/src/cartesian_trajectory.cpp
+++ b/cartesian_trajectory_interpolation/src/cartesian_trajectory.cpp
@@ -67,7 +67,7 @@ bool CartesianTrajectory::init(const cartesian_control_msgs::CartesianTrajectory
       sign_flipped = false;
     }
 
-    // If the dot product is negative, we change the sing of the orientation to not travel the long way around
+    // If the dot product is negative, we change the sign of the orientation to not travel the long way around
     double dot_product = state.q.dot(next_state.q);
     if (dot_product < 0.0)
     {


### PR DESCRIPTION
…polating between two orientations

Changed the order of multiplication when calculating the quaternion based velocity and acceleration, since the velocity and acceleration is given in the body-local reference frame. 
The math supporting this change, can be found [here](https://arxiv.org/abs/0811.2889v1).

Added unit tests to verify the changes.

If the dot product between two orientations is negative, the sign is flipped on one of them to ensure that we take the shortest path. Without this we could end up interpolating between two identical orientations, but with opposite signs.

This should fix the [issue](https://github.com/UniversalRobots/Universal_Robots_ROS_Driver/issues/540). 

To test the following motion will fail on the old version, but work with these changes.
start_pose.position = [-0.63316, -0.50412, 0.07724]
start_pose.orientation = [0.1046779, -0.7045626, 0.1234662, 0.6909343]

end_pose.position =  [-0.78590, -0.19334, 0.07724]
end_pose.orientation = [0.0485966, 0.7107247, 0.031284, -0.7010921]